### PR TITLE
feat: add parameteric descriptors

### DIFF
--- a/packages/pharaoh/lib/src/core_impl.dart
+++ b/packages/pharaoh/lib/src/core_impl.dart
@@ -83,6 +83,11 @@ class _$PharaohImpl extends RouterContract<Pharaoh>
     try {
       final result = await resolveAndExecuteHandlers(req, res);
       await forward(httpReq, result.res);
+    } on PharaohValidationError catch (e) {
+      await forward(
+        httpReq,
+        res.status(422).json(res.makeError(message: e.toString())),
+      );
     } catch (e) {
       await forward(httpReq, res.internalServerError(e.toString()));
     }

--- a/packages/pharaoh/lib/src/http/response.dart
+++ b/packages/pharaoh/lib/src/http/response.dart
@@ -184,13 +184,8 @@ class Response extends Message<shelf.Body?> implements $Response {
       if (data is Set) data = data.toList();
       result = jsonEncode(data);
     } catch (_) {
-      final errStr = jsonEncode(makeError(message: _.toString()).toJson);
-      return Response(
-        _httpReq,
-        statusCode: 500,
-        body: shelf.Body(errStr),
-        headers: headers,
-      ).type(ContentType.json).end();
+      final errStr = jsonEncode(makeError(message: _.toString()));
+      return type(ContentType.json).status(500).send(errStr);
     }
 
     final res = Response(
@@ -206,19 +201,18 @@ class Response extends Message<shelf.Body?> implements $Response {
 
   @override
   Response notFound([String? message]) {
-    return status(404).json(makeError(message: message ?? 'Not found').toJson);
+    return status(404).json(makeError(message: message ?? 'Not found'));
   }
 
   @override
   Response unauthorized({Object? data}) {
-    final error = data ?? makeError(message: 'Unauthorized').toJson;
+    final error = data ?? makeError(message: 'Unauthorized');
     return status(401).json(error);
   }
 
   @override
   Response internalServerError([String? message]) {
-    return status(500)
-        .json(makeError(message: message ?? 'Internal Server Error').toJson);
+    return status(500).json(makeError(message: message ?? 'Internal Server Error'));
   }
 
   @override
@@ -255,8 +249,11 @@ class Response extends Message<shelf.Body?> implements $Response {
     );
   }
 
-  PharaohErrorBody makeError({required String message}) =>
-      PharaohErrorBody(message, _reqInfo.path, method: _reqInfo.method);
+  PharaohErrorBody makeError({required String message}) => PharaohErrorBody(
+        message,
+        _reqInfo.path,
+        method: _reqInfo.method,
+      );
 
   ContentType _getContentType(
     Object data, {
@@ -284,8 +281,7 @@ class Response extends Message<shelf.Body?> implements $Response {
     final handler = options[reqAcceptType] ?? options['_'];
 
     if (handler == null) {
-      return status(HttpStatus.notAcceptable)
-          .json(makeError(message: 'Not Acceptable').toJson);
+      return status(HttpStatus.notAcceptable).json(makeError(message: 'Not Acceptable'));
     }
 
     return handler.call(this);

--- a/packages/pharaoh/lib/src/utils/exceptions.dart
+++ b/packages/pharaoh/lib/src/utils/exceptions.dart
@@ -20,7 +20,9 @@ class PharaohException extends Error {
       : invalidValue = value,
         _hasValue = true;
 
-  String get _errorName => "Pharaoh Error${!_hasValue ? "(s)" : ""}";
+  String get _errorName => "$parentName${!_hasValue ? "(s)" : ""}";
+
+  String get parentName => "Pharaoh Error";
 
   @override
   String toString() {
@@ -45,9 +47,19 @@ class PharaohErrorBody {
     required this.method,
   });
 
-  Map<String, dynamic> get toJson => {
+  Map<String, dynamic> toJson() => {
         "path": path,
         "method": method.name,
         "message": message,
       };
+}
+
+class PharaohValidationError extends PharaohException {
+  PharaohValidationError(
+    String message,
+    String invalidValue,
+  ) : super.value(message, invalidValue);
+
+  @override
+  String get parentName => 'Pharaoh Validation Error';
 }

--- a/packages/pharaoh/test/http/res.json_test.dart
+++ b/packages/pharaoh/test/http/res.json_test.dart
@@ -20,6 +20,21 @@ void main() {
           .test();
     });
 
+    test('should catch object serialization errors', () async {
+      final app = Pharaoh().get('/', (req, res) => res.json(Never));
+
+      await (await request<Pharaoh>(app))
+          .get('/')
+          .expectStatus(500)
+          .expectBody({
+            'path': '/',
+            'method': 'GET',
+            'message': "Converting object to an encodable object failed: Never"
+          })
+          .expectContentType('application/json; charset=utf-8')
+          .test();
+    });
+
     group('when given primitives', () {
       test('should respond with json for <null>', () async {
         final app = Pharaoh().use((req, res, next) {

--- a/packages/pharaoh_jwt_auth/lib/src/pharaoh_jwt_auth_base.dart
+++ b/packages/pharaoh_jwt_auth/lib/src/pharaoh_jwt_auth_base.dart
@@ -10,7 +10,7 @@ const _tokenNotFound = 'No authorization token was found';
 HandlerFunc jwtAuth({required FutureOr<JWTKey> Function() secret}) {
   return (req, res, next) async {
     void reject(String message) {
-      final error = res.makeError(message: message).toJson;
+      final error = res.makeError(message: message);
       next(res.unauthorized(data: error));
     }
 

--- a/packages/spanner/lib/src/parametric/descriptor.dart
+++ b/packages/spanner/lib/src/parametric/descriptor.dart
@@ -1,0 +1,22 @@
+import 'package:pharaoh/pharaoh.dart';
+
+import 'utils.dart';
+
+typedef ParameterDescriptor<T> = T Function(dynamic value);
+
+ParameterDescriptor<num> numDescriptor = (input) {
+  input = input.toString();
+  if (num.tryParse(input) == null) {
+    throw PharaohValidationError('Invalid parameter value', input);
+  }
+  return num.parse(input);
+};
+
+ParameterDescriptor regexDescriptor = (input) {
+  try {
+    final regex = descriptorToRegex(input);
+    if (regex.hasMatch(input.toString())) return input;
+  } catch (_) {}
+
+  throw PharaohValidationError('Invalid parameter value', input);
+};

--- a/packages/spanner/lib/src/parametric/utils.dart
+++ b/packages/spanner/lib/src/parametric/utils.dart
@@ -1,3 +1,4 @@
+import '../tree/utils.dart';
 import 'definition.dart';
 
 final parametricRegex = RegExp(r"<[^>]+>");
@@ -20,7 +21,16 @@ extension StringExtension on String {
 
   bool get isWildCard => codeUnitAt(0) == 42;
 
+  bool get isRegex => isRegexeric(this);
+
   String? get nullIfEmpty => isEmpty ? null : this;
+}
+
+/// converts `(^\\w+)` string value to Regex('\w+)
+RegExp descriptorToRegex(String descriptor) {
+  // Remove leading and trailing parentheses
+  String regexStr = descriptor.substring(1, descriptor.length - 1);
+  return RegExp(regexStr);
 }
 
 RegExp buildRegexFromTemplate(String template) {

--- a/packages/spanner/lib/src/parametric/utils.dart
+++ b/packages/spanner/lib/src/parametric/utils.dart
@@ -56,14 +56,13 @@ extension ParametricDefinitionsExtension on List<ParameterDefinition> {
     final Map<int, int> nullCount = {};
     for (final def in this) {
       int count = 0;
+      if (def.prefix == null) count += 1;
       if (def.suffix == null) count += 1;
-      if (def.regex == null) count += 1;
       nullCount[def.hashCode] = count;
     }
 
     sort((a, b) => nullCount[a.hashCode]!.compareTo(nullCount[b.hashCode]!));
   }
 
-  Iterable get methods =>
-      map((e) => e.methods).reduce((val, e) => {...val, ...e});
+  Iterable get methods => map((e) => e.methods).reduce((val, e) => {...val, ...e});
 }

--- a/packages/spanner/test/parametric_test.dart
+++ b/packages/spanner/test/parametric_test.dart
@@ -28,7 +28,7 @@ void main() {
 
         final exception = runSyncAndReturnException<ArgumentError>(router);
         expect(exception.message,
-            contains('Parameter definition is not valid. Close door neighbors'));
+            contains('Parameter definition is invalid. Close door neighbors'));
         expect(exception.invalidValue, '<userId><keyId>');
       });
 
@@ -36,7 +36,7 @@ void main() {
         router() => Spanner()..on(HTTPMethod.GET, '/user/<userId#@#.XDkd@#>>#>', okHdler);
 
         final exception = runSyncAndReturnException<ArgumentError>(router);
-        expect(exception.message, contains('Parameter definition is not valid'));
+        expect(exception.message, contains('Parameter definition is invalid'));
         expect(exception.invalidValue, '<userId#@#.XDkd@#>>#>');
       });
     });


### PR DESCRIPTION
This feature allows us to add descriptors to our parameter definitions. I could define a route like so
```dart
app.get('/users/<userId|(^\\w+)|number>/detail', (req, res) => res.json(req.params));

print(req.params); // ->   { 'userId' : Type(Number) }
```

## Description

<!--- Describe your changes in detail -->

The `Descriptors` are chained in the order in-which you write them. And If any of them fails, a `PharaohValidatorError` will be thrown and sent back with status code `422`.

Not all `Descriptors` do transformations. Some will just validate the parameter value and return it as is. Others will transform it eg: `number` in `<userId|number>`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
