### PR TITLE
feat: add view engine support 

### DIFF
--- a/packages/pharaoh/lib/pharaoh.dart
+++ b/packages/pharaoh/lib/pharaoh.dart
@@ -1,6 +1,6 @@
 library;
 
-export 'src/core.dart';
+export 'src/core.dart' hide $PharaohImpl;
 export 'src/view/view.dart';
 export 'src/http/cookie.dart';
 export 'src/http/request.dart';

--- a/packages/pharaoh/lib/pharaoh.dart
+++ b/packages/pharaoh/lib/pharaoh.dart
@@ -1,12 +1,13 @@
 library;
 
 export 'src/core.dart';
-export 'src/router/router_handler.dart';
+export 'src/view/view.dart';
 export 'src/http/cookie.dart';
 export 'src/http/request.dart';
 export 'src/http/response.dart';
 export 'src/utils/utils.dart';
 export 'src/utils/exceptions.dart';
+export 'src/router/router_handler.dart';
 export 'src/middleware/session_mw.dart';
 export 'src/middleware/cookie_parser.dart';
 export 'src/middleware/request_logger.dart';

--- a/packages/pharaoh/lib/src/core.dart
+++ b/packages/pharaoh/lib/src/core.dart
@@ -23,7 +23,7 @@ import 'shelf_interop/shelf.dart' as shelf;
 part 'core_impl.dart';
 
 abstract class Pharaoh implements RouterContract {
-  factory Pharaoh() => _$PharaohImpl();
+  factory Pharaoh() => $PharaohImpl();
 
   ViewEngine? get viewEngine;
 

--- a/packages/pharaoh/lib/src/core.dart
+++ b/packages/pharaoh/lib/src/core.dart
@@ -9,10 +9,12 @@ import 'http/response.dart';
 import 'http/response_impl.dart';
 import 'http/request_impl.dart';
 import 'middleware/session_mw.dart';
+import 'router/_handler_executor.dart';
 import 'router/router_contract.dart';
 import 'router/router_handler.dart';
 import 'router/router_mixin.dart';
 import 'router/router.dart';
+import 'view/view.dart';
 
 import 'middleware/body_parser.dart';
 import 'utils/exceptions.dart';
@@ -22,6 +24,10 @@ part 'core_impl.dart';
 
 abstract class Pharaoh implements RouterContract {
   factory Pharaoh() => _$PharaohImpl();
+
+  ViewEngine? get viewEngine;
+
+  set viewEngine(ViewEngine? engine);
 
   RouterContract router();
 

--- a/packages/pharaoh/lib/src/core_impl.dart
+++ b/packages/pharaoh/lib/src/core_impl.dart
@@ -3,6 +3,8 @@ part of 'core.dart';
 class _$PharaohImpl extends RouterContract with RouteDefinitionMixin implements Pharaoh {
   late final HttpServer _server;
 
+  ViewEngine? _viewEngine;
+
   final List<ReqResHook> _preResponseHooks = [
     sessionPreResponseHook,
   ];
@@ -167,6 +169,12 @@ class _$PharaohImpl extends RouterContract with RouteDefinitionMixin implements 
 
   @override
   Future<void> shutdown() async => _server.close();
+
+  @override
+  ViewEngine? get viewEngine => _viewEngine;
+
+  @override
+  set viewEngine(ViewEngine? engine) => _viewEngine = engine;
 }
 
 // ignore: constant_identifier_names

--- a/packages/pharaoh/lib/src/core_impl.dart
+++ b/packages/pharaoh/lib/src/core_impl.dart
@@ -1,15 +1,16 @@
 part of 'core.dart';
 
-class _$PharaohImpl extends RouterContract with RouteDefinitionMixin implements Pharaoh {
+class $PharaohImpl extends RouterContract with RouteDefinitionMixin implements Pharaoh {
   late final HttpServer _server;
 
-  ViewEngine? _viewEngine;
+  static ViewEngine? viewEngine_;
 
   final List<ReqResHook> _preResponseHooks = [
     sessionPreResponseHook,
+    viewRenderHook,
   ];
 
-  _$PharaohImpl() {
+  $PharaohImpl() {
     useSpanner(Spanner());
     use(bodyParser);
   }
@@ -171,10 +172,10 @@ class _$PharaohImpl extends RouterContract with RouteDefinitionMixin implements 
   Future<void> shutdown() async => _server.close();
 
   @override
-  ViewEngine? get viewEngine => _viewEngine;
+  ViewEngine? get viewEngine => viewEngine_;
 
   @override
-  set viewEngine(ViewEngine? engine) => _viewEngine = engine;
+  set viewEngine(ViewEngine? engine) => viewEngine_ = engine;
 }
 
 // ignore: constant_identifier_names

--- a/packages/pharaoh/lib/src/http/response.dart
+++ b/packages/pharaoh/lib/src/http/response.dart
@@ -39,7 +39,7 @@ abstract interface class Response {
 
   Response internalServerError([String? message]);
 
-  Response render(String name, Map<String, dynamic> data);
+  Response render(String name, [Map<String, dynamic> data]);
 
   Response end();
 }

--- a/packages/pharaoh/lib/src/http/response.dart
+++ b/packages/pharaoh/lib/src/http/response.dart
@@ -39,5 +39,7 @@ abstract interface class Response {
 
   Response internalServerError([String? message]);
 
+  Response render(String name, Map<String, dynamic> data);
+
   Response end();
 }

--- a/packages/pharaoh/lib/src/http/response_impl.dart
+++ b/packages/pharaoh/lib/src/http/response_impl.dart
@@ -22,6 +22,8 @@ class $Response extends Message<shelf.Body?> implements Response {
 
   final List<Cookie> _cookies = [];
 
+  ViewRenderData? viewToRender;
+
   DateTime? _expiresCache;
 
   /// The date and time after which the $Response's data should be considered
@@ -267,4 +269,16 @@ class $Response extends Message<shelf.Body?> implements Response {
     headers[HttpHeaders.setCookieHeader] = _cookies;
     return this;
   }
+
+  @override
+  Response render(String name, Map<String, dynamic> data) {
+    final viewData = ViewRenderData(name, data);
+    return type(ContentType.html)..viewToRender = viewData;
+  }
+}
+
+class ViewRenderData {
+  final String name;
+  final Map<String, dynamic> data;
+  const ViewRenderData(this.name, this.data);
 }

--- a/packages/pharaoh/lib/src/http/response_impl.dart
+++ b/packages/pharaoh/lib/src/http/response_impl.dart
@@ -271,10 +271,10 @@ class $Response extends Message<shelf.Body?> implements Response {
   }
 
   @override
-  Response render(String name, Map<String, dynamic> data) {
-    final viewData = ViewRenderData(name, data);
-    return type(ContentType.html)..viewToRender = viewData;
-  }
+  Response render(String name, [Map<String, dynamic> data = const {}]) => type(
+        ContentType.html,
+      ).end()
+        ..viewToRender = ViewRenderData(name, data);
 }
 
 class ViewRenderData {

--- a/packages/pharaoh/lib/src/http/response_impl.dart
+++ b/packages/pharaoh/lib/src/http/response_impl.dart
@@ -5,6 +5,7 @@ import 'package:http_parser/http_parser.dart';
 
 import '../shelf_interop/shelf.dart' as shelf;
 import '../utils/exceptions.dart';
+import '../view/view.dart';
 import 'cookie.dart';
 import 'message.dart';
 import 'request.dart';
@@ -275,10 +276,4 @@ class $Response extends Message<shelf.Body?> implements Response {
         ContentType.html,
       ).end()
         ..viewToRender = ViewRenderData(name, data);
-}
-
-class ViewRenderData {
-  final String name;
-  final Map<String, dynamic> data;
-  const ViewRenderData(this.name, this.data);
 }

--- a/packages/pharaoh/lib/src/router/_handler_executor.dart
+++ b/packages/pharaoh/lib/src/router/_handler_executor.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+import 'router_handler.dart';
+
+typedef HandlerResult = ({bool canNext, ReqRes reqRes});
+
+final class Executor {
+  final Middleware _handler;
+
+  Executor(this._handler);
+
+  StreamController<Middleware>? _streamCtrl;
+
+  Future<HandlerResult> execute(final ReqRes reqRes) async {
+    await _resetStream();
+    final streamCtrl = _streamCtrl!;
+
+    ReqRes result = reqRes;
+    bool canGotoNext = false;
+
+    await for (final executor in streamCtrl.stream) {
+      canGotoNext = false;
+      await executor.call(result.req, result.res, ([nr_, chain]) {
+        result = result.merge(nr_);
+        canGotoNext = true;
+
+        if (chain == null || result.res.ended) {
+          streamCtrl.close();
+        } else {
+          streamCtrl.add(chain);
+        }
+      });
+    }
+
+    return (canNext: canGotoNext, reqRes: result);
+  }
+
+  Future<void> _resetStream() async {
+    void newStream() => _streamCtrl = StreamController<Middleware>()..add(_handler);
+    final ctrl = _streamCtrl;
+    if (ctrl == null) return newStream();
+    if (ctrl.hasListener && ctrl.isClosed) await ctrl.close();
+    return newStream();
+  }
+}

--- a/packages/pharaoh/lib/src/view/view.dart
+++ b/packages/pharaoh/lib/src/view/view.dart
@@ -15,6 +15,12 @@ abstract class ViewEngine {
   FutureOr<String> render(String template, Map<String, dynamic> data);
 }
 
+class ViewRenderData {
+  final String name;
+  final Map<String, dynamic> data;
+  const ViewRenderData(this.name, this.data);
+}
+
 class JinjaViewEngine implements ViewEngine {
   final String fileExt;
   late final Environment _environment;

--- a/packages/pharaoh/lib/src/view/view.dart
+++ b/packages/pharaoh/lib/src/view/view.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import 'package:jinja/jinja.dart';
+
+abstract class ViewEngine {
+  String get name;
+
+  FutureOr<String> render(String template, Map<String, dynamic> data);
+}
+
+class JinjaViewEngine implements ViewEngine {
+  final String fileExt;
+  final List<String> filePaths;
+  late final Environment _environment;
+
+  JinjaViewEngine(
+    this._environment, {
+    this.filePaths = const [],
+    this.fileExt = 'html',
+  });
+
+  @override
+  FutureOr<String> render(
+    String name,
+    Map<String, dynamic> data,
+  ) =>
+      _environment.getTemplate('$name.$fileExt').render(data);
+
+  @override
+  String get name => 'Jinja';
+}

--- a/packages/pharaoh/pubspec.yaml
+++ b/packages/pharaoh/pubspec.yaml
@@ -14,7 +14,8 @@ dependencies:
   crypto: ^3.0.3
   uuid: ^4.2.1
   spanner: ^1.0.0
-
+  jinja: ^0.5.0
+  
   # We only need this to implement inter-operability for shelf
   shelf: ^1.4.1
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

I've added support for template rendering by calling `res.render('template', data)`. The templates get rendering in a separate Isolate as well.
```dart
  app.get('/', (req, res) => res.render('index')); // -> can take optional positional parameter Map<String, dynamic>
``` 

Pharaoh comes with a default [Jinja](https://jinja.palletsprojects.com/en/3.1.x/) View Engine. which you can initialize like this
```dart
  final app = Pharaoh();
  
  final env = Environment(
    autoReload: false,
    trimBlocks: true,
    leftStripBlocks: true,
    loader: FileSystemLoader(paths: ['public']),
  );
  app.viewEngine = JinjaViewEngine(env);
```

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
